### PR TITLE
Add Player and Team Names to Selection Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
         multiDexEnabled true
+        vectorDrawables.useSupportLibrary = true
     }
     applicationVariants.all { variant ->
         variant.resValue "string", "versionName", "Version " + variant.versionName

--- a/app/src/main/res/drawable/Blinky.xml
+++ b/app/src/main/res/drawable/Blinky.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="684dp"
-        android:height="683dp"
+        android:width="@dimen/character_icon_radio_size"
+        android:height="@dimen/character_icon_radio_size"
         android:viewportWidth="684.5768"
         android:viewportHeight="683.5574">
     <path

--- a/app/src/main/res/drawable/Clyde.xml
+++ b/app/src/main/res/drawable/Clyde.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="684dp"
-        android:height="683dp"
+        android:width="@dimen/character_icon_radio_size"
+        android:height="@dimen/character_icon_radio_size"
         android:viewportWidth="684.5768"
         android:viewportHeight="683.5574">
     <path

--- a/app/src/main/res/drawable/Inky.xml
+++ b/app/src/main/res/drawable/Inky.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="684dp"
-        android:height="683dp"
+        android:width="@dimen/character_icon_radio_size"
+        android:height="@dimen/character_icon_radio_size"
         android:viewportWidth="684.5768"
         android:viewportHeight="683.5574">
     <path

--- a/app/src/main/res/drawable/Pacman.xml
+++ b/app/src/main/res/drawable/Pacman.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="541dp"
-        android:height="571dp"
+        android:width="@dimen/character_icon_radio_size"
+        android:height="@dimen/character_icon_radio_size"
         android:viewportWidth="541.6"
         android:viewportHeight="571.11">
     <path

--- a/app/src/main/res/drawable/Pinky.xml
+++ b/app/src/main/res/drawable/Pinky.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="684dp"
-        android:height="683dp"
+        android:width="@dimen/character_icon_radio_size"
+        android:height="@dimen/character_icon_radio_size"
         android:viewportWidth="684.5768"
         android:viewportHeight="683.5574">
     <path

--- a/app/src/main/res/drawable/radio_button_text_selector.xml
+++ b/app/src/main/res/drawable/radio_button_text_selector.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="false" android:color="@color/colorAccent"/>
-    <item android:state_checked="true" android:color="@color/colorPrimary"/>
+    <item android:state_checked="false" android:color="@color/colorPrimary"/>
+    <item android:state_checked="true" android:color="@color/colorAccent"/>
 </selector>

--- a/app/src/main/res/layout/character_radio_group.xml
+++ b/app/src/main/res/layout/character_radio_group.xml
@@ -8,8 +8,8 @@
     android:id="@+id/character_selection">
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/character_pacman"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/pacman_name"
@@ -20,8 +20,8 @@
         soulwolf:mcButton="@drawable/pacman" />
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/character_inky"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/inky_name"
@@ -32,8 +32,8 @@
         soulwolf:mcButton="@drawable/inky"/>
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/character_blinky"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/blinky_name"
@@ -44,8 +44,8 @@
         soulwolf:mcButton="@drawable/blinky"/>
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/character_pinky"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/pinky_name"
@@ -56,8 +56,8 @@
         soulwolf:mcButton="@drawable/pinky"/>
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/character_clyde"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/clyde_name"

--- a/app/src/main/res/layout/team_radio_group.xml
+++ b/app/src/main/res/layout/team_radio_group.xml
@@ -8,20 +8,20 @@
     android:id="@+id/team_selection">
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/team_pacman"
         soulwolf:mcTextSize="6sp"
-        soulwolf:mcText="@string/pacman_team_name"
+        soulwolf:mcText="Hello, World!"
         soulwolf:mcPadding="5dp"
         soulwolf:mcChecked="false"
         soulwolf:mcAnimator="true"
         soulwolf:mcTextColor="@drawable/radio_button_text_selector"
-        soulwolf:mcButton="@drawable/pacman" />
+        soulwolf:mcButton="@drawable/pacman"/>
 
     <net.soulwolf.widget.materialradio.MaterialRadioButton
-        android:layout_width="@dimen/character_icon_radio_width"
-        android:layout_height="@dimen/character_icon_radio_height"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
         android:id="@+id/team_ghost"
         soulwolf:mcTextSize="6sp"
         soulwolf:mcText="@string/ghost_team_name"

--- a/app/src/main/res/layout/team_radio_group.xml
+++ b/app/src/main/res/layout/team_radio_group.xml
@@ -12,7 +12,7 @@
         android:layout_height="match_parent"
         android:id="@+id/team_pacman"
         soulwolf:mcTextSize="6sp"
-        soulwolf:mcText="Hello, World!"
+        soulwolf:mcText="@string/pacman_team_name"
         soulwolf:mcPadding="5dp"
         soulwolf:mcChecked="false"
         soulwolf:mcAnimator="true"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,8 +4,7 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
-    <dimen name="character_icon_radio_height">90dp</dimen>
-    <dimen name="character_icon_radio_width">70dp</dimen>
+    <dimen name="character_icon_radio_size">70dp</dimen>
     <dimen name="character_map_icon_size">24dp</dimen>
     <dimen name="mobify_icon_height">100dp</dimen>
     <dimen name="mobify_icon_width">357dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,5 +24,5 @@
     <string name="csss_logo_content_description">CSSS logo</string>
     <string name="credits_activity_sponsors_heading">Sponsors</string>
     <string name="pacman_team_name">Pacman\'s Team</string>
-    <string name="ghost_team_name">Ghost\'s Team</string>
+    <string name="ghost_team_name">Ghosts\' Team</string>
 </resources>


### PR DESCRIPTION
Closes #15 

Note: #15 only requested for player names to be added, but I also added team names for consistency. If this is not desired, it can be changed easily

Implementation Details
- The player and team name texts were actually already programmed to display, but were not showing up properly. The issue was that the vector drawable character icons was filling the entire Image radio button, and covering up the text
- Resize vector drawable intended size
- Remove character icon width/height dimensions, and replace with a character icon "size" dimension to be used for both width and height (so they are the same length)
- Enable vector support library so that vector drawable resources work on older devices, and to fix an issue with referencing dimension resources from within them
- Set width and height of player/team radio buttons to wrap_content and match_parent respectively