### PR TITLE
Add Confirmation Dialog When Selecting Pacman Team as Spectator

### DIFF
--- a/app/src/main/java/ca/sfu/pacmacro/PlayerFragment.java
+++ b/app/src/main/java/ca/sfu/pacmacro/PlayerFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -52,6 +53,7 @@ public class PlayerFragment extends Fragment {
             public void onClick(View v) {
                 Character.CharacterType selectedCharacter = null;
                 int selectedCharacterId = characterSelection.getCheckedRadioButtonId();
+                boolean isPlayerSelected = true;
                 switch (selectedCharacterId) {
                     case R.id.character_pacman:
                         selectedCharacter = Character.CharacterType.PACMAN;
@@ -68,13 +70,21 @@ public class PlayerFragment extends Fragment {
                     case R.id.character_clyde:
                         selectedCharacter = Character.CharacterType.CLYDE;
                         break;
+                    default:
+                        isPlayerSelected = false;
+
+                        AlertDialog.Builder makeSelectionBuilder = new AlertDialog.Builder(PlayerFragment.this.getContext());
+                        makeSelectionBuilder.setTitle(R.string.dialog_title_select_player);
+                        makeSelectionBuilder.setPositiveButton(R.string.dialog_button_ok, null);
+                        makeSelectionBuilder.show();
                 }
 
-                Toast.makeText(getContext(), "Character selected: " + selectedCharacter, Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(getContext(), PlayerActivity.class);
-                intent.putExtra("Character", selectedCharacter);
-                startActivity(intent);
-
+                if (isPlayerSelected) {
+                    Toast.makeText(getContext(), "Character selected: " + selectedCharacter, Toast.LENGTH_SHORT).show();
+                    Intent intent = new Intent(getContext(), PlayerActivity.class);
+                    intent.putExtra("Character", selectedCharacter);
+                    startActivity(intent);
+                }
             }
         };
     }

--- a/app/src/main/java/ca/sfu/pacmacro/SpectatorFragment.java
+++ b/app/src/main/java/ca/sfu/pacmacro/SpectatorFragment.java
@@ -1,9 +1,11 @@
 package ca.sfu.pacmacro;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,21 +50,37 @@ public class SpectatorFragment extends Fragment {
         return new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                int selectedTeam = 1;
                 int teamId = teamSelection.getCheckedRadioButtonId();
                 switch(teamId) {
                     case R.id.team_ghost:
-                        selectedTeam = CharacterDisplayCriteria.CRITERIA_GHOST_TEAM;
+                        goToSpectatorActivity(CharacterDisplayCriteria.CRITERIA_GHOST_TEAM);
                         break;
                     case R.id.team_pacman:
-                        selectedTeam = CharacterDisplayCriteria.CRITERIA_PACMAN_TEAM;
+                        AlertDialog.Builder confirmSelectionBuilder = new AlertDialog.Builder(SpectatorFragment.this.getContext());
+                        confirmSelectionBuilder.setTitle(R.string.dialog_title_confirm_team);
+                        confirmSelectionBuilder.setNegativeButton(R.string.dialog_button_cancel, null);
+                        confirmSelectionBuilder.setPositiveButton(R.string.dialog_button_confirm, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                goToSpectatorActivity(CharacterDisplayCriteria.CRITERIA_PACMAN_TEAM);
+                            }
+                        });
+                        confirmSelectionBuilder.show();
                         break;
+                    default:
+                        AlertDialog.Builder makeSelectionBuilder = new AlertDialog.Builder(SpectatorFragment.this.getContext());
+                        makeSelectionBuilder.setTitle(R.string.dialog_title_select_team);
+                        makeSelectionBuilder.setPositiveButton(R.string.dialog_button_ok, null);
+                        makeSelectionBuilder.show();
                 }
-                Intent intent = new Intent(getContext(), SpectatorActivity.class);
-                intent.putExtra(CharacterDisplayCriteria.EXTRA_KEY, selectedTeam);
-                startActivity(intent);
             }
         };
+    }
+
+    private void goToSpectatorActivity(int selectedTeam) {
+        Intent intent = new Intent(getContext(), SpectatorActivity.class);
+        intent.putExtra(CharacterDisplayCriteria.EXTRA_KEY, selectedTeam);
+        startActivity(intent);
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,10 @@
     <string name="credits_activity_sponsors_heading">Sponsors</string>
     <string name="pacman_team_name">Pacman\'s Team</string>
     <string name="ghost_team_name">Ghost\'s Team</string>
+    <string name="dialog_title_select_team">Please Select a Team</string>
+    <string name="dialog_title_confirm_team">Confirm Team Selection</string>
+    <string name="dialog_button_cancel">Cancel</string>
+    <string name="dialog_button_confirm">Confirm</string>
+    <string name="dialog_button_ok">OK</string>
+    <string name="dialog_title_select_player">Please Select a Player</string>
 </resources>


### PR DESCRIPTION
Closes #14 

Note: the Confirmation dialog only appears when selecting the Pacman team (as specified by #14). This means if the ghost team is selected, there is no confirmation. If confirmation is also desired for the ghost team, this can be added easily.

- Allow the user to confirm that they want to select the Pacman team
- Also check if the user selected a team/player, and display an alert if they didn't make a selection